### PR TITLE
fix: show only verified projects in SSO sidebar

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -20,10 +20,10 @@ logger = logging.getLogger(__name__)
 def home(request):
     """
     Show the homepage. If the user is logged in, display their current and previous SSO sessions,
-    as well as all available Project. If the user is not logged in, show the default homepage.
+    as well as all verified Project. If the user is not logged in, show the default homepage.
     """
 
-    project = Project.objects.all()
+    project = Project.objects.filter(is_verified=True)
 
     if request.user.is_authenticated:
         sso_sessions = SSOSession.objects.filter(user=request.user).order_by('-created_at')[0:5]


### PR DESCRIPTION

<img width="236" height="470" alt="Screenshot 2025-10-10 at 18 17 28" src="https://github.com/user-attachments/assets/5e02c284-30b0-4c20-839c-b9d062122d11" />


- Updated home view to filter projects by is_verified=True
- Previously all projects were shown regardless of verification status
- Now only admin-verified projects appear in SSO Access Projects sidebar
- Unverified projects remain hidden until admin approval