### PR TITLE
Use Picsum placeholder for project logo

### DIFF
--- a/templates/projects/project_details.html
+++ b/templates/projects/project_details.html
@@ -30,7 +30,7 @@
       "
     >
       <img
-        src="{{ project.logo.url|default:'https://via.placeholder.com/80' }}"
+        src="{{ project.logo.url|default:'https://picsum.photos/id/29/60' }}"
         alt="{{ project.name }}"
         style="
           width: 80px;


### PR DESCRIPTION
Replace the default fallback image URL in templates/projects/project_details.html from via.placeholder.com/80 to https://picsum.photos/id/29/60 so a Picsum image is shown when no project.logo is provided. Note: the placeholder request is for 60px while the img style sets width: 80px; adjust sizes if consistent dimensions are required.