### PR TITLE
Use conditional project logo with placeholder

### DIFF
--- a/templates/projects/manage_projects.html
+++ b/templates/projects/manage_projects.html
@@ -33,18 +33,19 @@ My Projects — ITC SSO
       <div class="card-body" style="padding: 24px">
         <div style="display: flex; align-items: center; gap: 20px">
           <!-- Project Logo -->
-          <img
-            src="{{ project.logo.url|default:'https://via.placeholder.com/60' }}"
-            alt="{{ project.name }}"
-            style="
-              width: 60px;
-              height: 60px;
-              object-fit: cover;
-              border-radius: 12px;
-              flex-shrink: 0;
-            "
-          />
-
+        {% if project.logo %}
+  <img
+    src="{{ project.logo.url }}"
+    alt="{{ project.name }}"
+    style="width: 60px; height: 60px; object-fit: cover; border-radius: 12px; flex-shrink: 0;"
+  />
+{% else %}
+  <img
+    src="https://picsum.photos/id/29/60"
+    alt="No logo"
+    style="width: 60px; height: 60px; object-fit: cover; border-radius: 12px; flex-shrink: 0;"
+  />
+{% endif %}
           <!-- Project Info -->
           <div style="flex: 1; min-width: 0">
             <h3 class="text-title-3" style="margin-bottom: 6px">

--- a/templates/projects/project_details.html
+++ b/templates/projects/project_details.html
@@ -30,16 +30,16 @@
       "
     >
       <img
-        src="{{ project.logo.url|default:'https://picsum.photos/id/29/60' }}"
-        alt="{{ project.name }}"
-        style="
-          width: 80px;
-          height: 80px;
-          object-fit: cover;
-          border-radius: 16px;
-          flex-shrink: 0;
-        "
-      />
+    src="{{ project.logo.url }}"
+    alt="{{ project.name }}"
+    style="width: 60px; height: 60px; object-fit: cover; border-radius: 12px; flex-shrink: 0;"
+  />
+{% else %}
+  <img
+    src="https://picsum.photos/id/29/60"
+    alt="No logo"
+    style="width: 60px; height: 60px; object-fit: cover; border-radius: 12px; flex-shrink: 0;"
+  />
       <div style="min-width: 0">
         <h1 class="text-title-1" style="margin-bottom: 8px">
           {{ project.name }}


### PR DESCRIPTION
Replace |default placeholder usage with an explicit {% if project.logo %} check in project templates and provide a Picsum fallback image. Standardize logo markup and styling (size, border-radius, object-fit) across manage_projects.html and project_details.html so missing logos render a consistent placeholder.